### PR TITLE
Fix nil serialization bug (nil -> "")

### DIFF
--- a/lib/openactive/helpers/json_ld.rb
+++ b/lib/openactive/helpers/json_ld.rb
@@ -74,6 +74,8 @@ module OpenActive
             )
           elsif value.is_a?(Numeric)
             value
+          elsif value.nil? # let nil be nil
+            nil
           else
             value.to_s
           end


### PR DESCRIPTION
This ensures that nil fields are serialized to nil, rather than an empty string.

This resolves a bug in the Dataset implementation where platform is seen as present despite being set to nil.