### PR TITLE
Add time validator

### DIFF
--- a/lib/openactive.rb
+++ b/lib/openactive.rb
@@ -26,6 +26,7 @@ module OpenActive
   require "openactive/validators/null_validator"
   require "openactive/validators/number_validator"
   require "openactive/validators/string_validator"
+  require "openactive/validators/time_validator"
   require "openactive/validators/uri_validator"
 
   require "openactive/base_model"

--- a/lib/openactive/validators/base_validator.rb
+++ b/lib/openactive/validators/base_validator.rb
@@ -52,6 +52,8 @@ module OpenActive
           case type
           when "URI"
             UriValidator.new
+          when "Time"
+            TimeValidator.new
           when "DateTime"
             DateTimeValidator.new
           when "DateInterval"

--- a/lib/openactive/validators/time_validator.rb
+++ b/lib/openactive/validators/time_validator.rb
@@ -1,0 +1,29 @@
+module OpenActive
+  module Validators
+    # https://schema.org/Time
+    # format spec: https://www.w3.org/TR/xmlschema-2/#time
+    class TimeValidator < BaseValidator
+      # https://www.oreilly.com/library/view/regular-expressions-cookbook/9781449327453/ch04s07.html#id2175516
+      # Minor additions to make second values and timezone optional
+      REGEX = /(?<hour>2[0-3]|[01][0-9]):?(?<minute>[0-5][0-9]):?(?<second>[0-5][0-9])?(?<timezone>Z|[+-](?:2[0-3]|[01][0-9])(?::?(?:[0-5][0-9]))?)?/
+
+      # Coerce given value to the type the validator is validating against.
+      # PLEASE NOTE: no checks are performed on the given value.
+      # It is therefore recommended to call the "run" method first before this.
+      #
+      # @param value [mixed] The value to coerce.
+      # @return [mixed] The same value.
+      def coerce(value)
+        value
+      end
+
+      # Run validation on the given value.
+      #
+      # @param value [mixed] The value to validate.
+      # @return [Boolean] Whether validation passes or not.
+      def run(value)
+        REGEX =~ value
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allows for various formats:
```
[1] pry(main)> OpenActive::Models::PartialSchedule.deserialize({"startTime": "20:15:00"}.to_json)
=> #<OpenActive::Models::PartialSchedule:0x00007fdd7db413f8 @start_time="20:15:00">

[2] pry(main)> OpenActive::Models::PartialSchedule.deserialize({"startTime": "20:15:00Z"}.to_json)
=> #<OpenActive::Models::PartialSchedule:0x00007fdd7e385618 @start_time="20:15:00Z">

[3] pry(main)> OpenActive::Models::PartialSchedule.deserialize({"startTime": "20:15:0"}.to_json)
=> #<OpenActive::Models::PartialSchedule:0x00007fdd7e847c78 @start_time="20:15:0">

[4] pry(main)> OpenActive::Models::PartialSchedule.deserialize({"startTime": "20:15"}.to_json)
=> #<OpenActive::Models::PartialSchedule:0x00007fdd7f133260 @start_time="20:15">
```

Prevents parsing invalid times
```
[5] pry(main)> OpenActive::Models::PartialSchedule.deserialize({"startTime": "20"}.to_json)
StandardError: error setting field "start_time"
from /Users/joecarter/projects/ODI/Ruby_Spike/lib/openactive/concerns/type_checker.rb:59:in `check_types'
Caused by StandardError: The first argument type does not match any of the declared parameter types (Time,null) for 20.
from /Users/joecarter/projects/ODI/Ruby_Spike/lib/openactive/concerns/type_checker.rb:59:in `check_types'
```