### PR TITLE
Fix order of schema.org context

### DIFF
--- a/lib/openactive/helpers/json_ld.rb
+++ b/lib/openactive/helpers/json_ld.rb
@@ -28,8 +28,8 @@ module OpenActive
 
             data["@context"] =
               [
+                *(schema ? ["https://schema.org"] : []),
                 *obj.context,
-                *(schema ? ["https://schema.org"] : [])
               ]
           end
 


### PR DESCRIPTION
> - "@context" must include "https://schema.org" as the _first_ element of the array (it's there, but not as the first element)
