### PR TITLE
Add pretty print flag to the .to_json

### DIFF
--- a/lib/openactive/base_model.rb
+++ b/lib/openactive/base_model.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 module OpenActive
   class BaseModel
     include OpenActive::Concerns::JsonLdSerializable
@@ -112,8 +114,12 @@ module OpenActive
       self.class.serialize(self, **kwargs)
     end
 
-    def to_json(*args, schema: false, **kwargs)
-      serialize(schema: schema).to_json(*args, **kwargs)
+    def to_json(schema: false, pretty: false)
+      serialized = serialize(schema: schema)
+
+      return JSON.pretty_generate(serialized) if pretty
+
+      serialized.to_json
     end
   end
 end


### PR DESCRIPTION
Adds a pretty print flag for the .to_json method on BaseModel. This is one part of pretty-printing on the dataset sites.
> - Also could we pretty-print the JSON into the HTML to match the other libraries