### PR TITLE
Make BigDecimal serialize to decimal notation (rather than scientific notation)

### DIFF
--- a/lib/openactive/helpers/json_ld.rb
+++ b/lib/openactive/helpers/json_ld.rb
@@ -68,6 +68,8 @@ module OpenActive
               parent,
               **kwargs,
             )
+          elsif value.is_a?(BigDecimal)
+            value.to_s('F')
           elsif value.is_a?(Numeric)
             value
           elsif value.nil? # let nil be nil


### PR DESCRIPTION
> - "price": "0.314e3"
> - Seems to have been recently introduced?

Fixes the serialization of BigDecimal to use decimal/floating point notation rather scientific / exponent.
https://apidock.com/ruby/BigDecimal/to_s

After the fix, the value quoted above should be "314".

One note, this is for the serialization of Schema Numbers:
- The spec seems to imply that it's a textual representation of the number rather than a native JSON number, https://schema.org/Number (although, this could be more down to Schema not being coupled to any particular format).
- It ensures that precision isn't lost due to floating point errors + rounding.