### PR TITLE
Serialize Numbers as floats

### DIFF
--- a/lib/openactive/helpers/json_ld.rb
+++ b/lib/openactive/helpers/json_ld.rb
@@ -87,7 +87,7 @@ module OpenActive
               **kwargs,
             )
           elsif value.is_a?(BigDecimal)
-            value.to_s('F')
+            value.to_f
           elsif value.is_a?(Numeric)
             value
           elsif value.nil? # let nil be nil


### PR DESCRIPTION
Corrects the serialization to use floats.

![image](https://user-images.githubusercontent.com/705668/71886211-b3ed7c00-3133-11ea-81ef-29fffb02883a.png)
