### PR TITLE
Remove @ from RpdeItem id field

### DIFF
--- a/lib/openactive/rpde/rpde_item.rb
+++ b/lib/openactive/rpde/rpde_item.rb
@@ -3,7 +3,7 @@ module OpenActive
     class RpdeItem < OpenActive::BaseModel
       define_property :state, types: ["OpenActive::Rpde::RpdeState"]
       define_property :kind, types: ["OpenActive::Rpde::RpdeKind"]
-      define_property :id, types: ["string", "int"], as: "@id"
+      define_property :id, types: ["string", "int"], as: "id"
       define_property :modified, types: ["int"]
       define_property :data, types: ["OpenActive::BaseModel", "null"]
     end

--- a/spec/fixtures/files/rpde/session_series-items.json
+++ b/spec/fixtures/files/rpde/session_series-items.json
@@ -2,7 +2,7 @@
   {
     "state": "updated",
     "kind": "SessionSeries",
-    "@id": "2",
+    "id": "2",
     "modified": 4,
     "data": {
       "@context": [
@@ -48,7 +48,7 @@
   {
     "state": "deleted",
     "kind": "SessionSeries",
-    "@id": "1",
+    "id": "1",
     "modified": 5
   }
 ]


### PR DESCRIPTION
When validating an RPDE feed generated using this gem we got validation errors caused by `@` being prepended to the RPDE item id field.

According to Nick Evans' message on the OpenActive Slack:
> this is because RPDE is not JSON-LD based - only everything within
> the RPDE property `data`, where the `@context` is defined, is JSON-LD
> and hence uses `@id`

Therefore changing OpenActive::Rpde::RpdeItem#id property to be `id` instead of `@id`.