### PR TITLE
Ensure booleans are not serialized as strings

### DIFF
--- a/lib/openactive/helpers/json_ld.rb
+++ b/lib/openactive/helpers/json_ld.rb
@@ -90,6 +90,8 @@ module OpenActive
             value.to_f
           elsif value.is_a?(Numeric)
             value
+          elsif value.is_a?(TrueClass) || value.is_a?(FalseClass)
+            value
           elsif value.nil? # let nil be nil
             nil
           else

--- a/spec/example_event_spec.rb
+++ b/spec/example_event_spec.rb
@@ -66,6 +66,7 @@ RSpec.describe "Example Event" do
             valid_from: DateTime.parse("2017-01-20T16:20:00-08:00"),
           )
         ],
+        isAccessibleForFree: false,
         attendee_instructions: "Ensure you bring trainers and a bottle of water.",
         meeting_point: "",
       )

--- a/spec/fixtures/files/example_event/session_series.json
+++ b/spec/fixtures/files/example_event/session_series.json
@@ -34,6 +34,7 @@
       "validFrom":"2017-01-20T16:20:00-08:00"
     }
   ],
+  "isAccessibleForFree": false,
   "startDate":"2017-04-24T19:30:00-08:00",
   "endDate":"2017-04-24T23:00:00-08:00",
   "attendeeInstructions":"Ensure you bring trainers and a bottle of water."


### PR DESCRIPTION
The JSON-LD serializer was serializing booleans as "true"/"false", but it should be serializing them as true/false.