### PR TITLE
Remove specific version of bundler from gemspec

### DIFF
--- a/lib/openactive.rb
+++ b/lib/openactive.rb
@@ -1,7 +1,9 @@
-require 'json'
+require 'active_support'
 require 'active_support/duration'
 require 'active_support/core_ext/date_time'
+require 'json'
 require 'typesafe_enum'
+
 module OpenActive
   require "openactive/version"
 

--- a/openactive.gemspec
+++ b/openactive.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 2.2.13"
   spec.add_development_dependency "rake", "~> 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-json_expectations"

--- a/openactive.gemspec
+++ b/openactive.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-rspec"
   spec.add_development_dependency "yard"
 
-  spec.add_runtime_dependency "activesupport"
+  spec.add_runtime_dependency "activesupport", '~> 6.1'
   spec.add_runtime_dependency "typesafe_enum"
 end

--- a/openactive.gemspec
+++ b/openactive.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-json_expectations"
-  spec.add_development_dependency "rubocop", "0.82.0"
+  spec.add_development_dependency "rubocop", "1.26.1"
   spec.add_development_dependency "rubocop-rspec"
   spec.add_development_dependency "yard"
 


### PR DESCRIPTION
Removes bundler from the gemspec.

Also pins the version of activesupport (as this was unbound and would fetch the latest most compatible version), and updates rubocop for compatability