### PR TITLE
fix: Update for Ruby 3

### DIFF
--- a/spec/data_structure/data_structure_spec.rb
+++ b/spec/data_structure/data_structure_spec.rb
@@ -18,7 +18,9 @@ RSpec.describe "Data structure tests" do
       }
     ]
 
-  objs.each do |model:, data:|
+  objs.each do |obj|
+    model = obj[:model]
+    data = obj[:data]
     describe model do
       let(:inst) { model.deserialize(data) }
 

--- a/spec/data_typing/data_typing_spec.rb
+++ b/spec/data_typing/data_typing_spec.rb
@@ -15,7 +15,10 @@ RSpec.describe "Data typing" do
       }
     ]
 
-  objs.each do |model:, data:|
+  objs.each do |obj|
+    model = obj[:model]
+    data = obj[:data]
+    
     describe model do
       describe "#type" do
         it "reserializes to original value" do


### PR DESCRIPTION
Ruby 3 requires a different way to handle keyword arguments within blocks.

This change is backwards compatible with Ruby 2.6. By using a single block parameter and then extracting the values within the block, this approach will work in both Ruby 2.6 and Ruby 3.