### PR TITLE
fix: Upgrade for compatibility with Ruby 3

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7']
+        ruby-version: ['2.7', '3.0', '3.1']
 
     steps:
     - uses: actions/checkout@v2

--- a/lib/openactive/concerns/json_ld_serializable.rb
+++ b/lib/openactive/concerns/json_ld_serializable.rb
@@ -25,16 +25,18 @@ module OpenActive
 
       def values
         data = {}
-        self.class.properties.each do |key, field:|
-          data[key] = send(field)
+        self.class.properties.each do |key, field|
+          field_value = field[:field]
+          data[key] = send(field_value)
         end
         data
       end
 
       def to_h
         data = {}
-        self.class.properties.each do |_key, field:|
-          data[field] = send(field)
+        self.class.properties.each do |_key, field|
+          field_value = field[:field]
+          data[field_value] = send(field_value)
         end
         data
       end


### PR DESCRIPTION
Ruby 3 requires a different way to handle keyword arguments within blocks.

This change is backwards compatible with Ruby 2.6. By using a single block parameter and then extracting the values within the block, this approach will work in both Ruby 2.6 and Ruby 3.