### PR TITLE
fix: Remove pin on activesupport version

### DIFF
--- a/lib/openactive/validators/number_validator.rb
+++ b/lib/openactive/validators/number_validator.rb
@@ -1,3 +1,5 @@
+require 'bigdecimal'
+
 module OpenActive
   module Validators
     class NumberValidator < BaseValidator

--- a/openactive.gemspec
+++ b/openactive.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-rspec"
   spec.add_development_dependency "yard"
 
-  spec.add_runtime_dependency "activesupport", '=> 6.1'
+  spec.add_runtime_dependency "activesupport"
   spec.add_runtime_dependency "typesafe_enum"
 end

--- a/openactive.gemspec
+++ b/openactive.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-rspec"
   spec.add_development_dependency "yard"
 
-  spec.add_runtime_dependency "activesupport"
+  spec.add_runtime_dependency "activesupport", '>= 6.1', '< 8.0'
   spec.add_runtime_dependency "typesafe_enum"
 end

--- a/openactive.gemspec
+++ b/openactive.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-rspec"
   spec.add_development_dependency "yard"
 
-  spec.add_runtime_dependency "activesupport", '>= 6.1', '< 8.0'
+  spec.add_runtime_dependency "activesupport"
   spec.add_runtime_dependency "typesafe_enum"
 end

--- a/openactive.gemspec
+++ b/openactive.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-rspec"
   spec.add_development_dependency "yard"
 
-  spec.add_runtime_dependency "activesupport", '~> 6.1'
+  spec.add_runtime_dependency "activesupport", '=> 6.1'
   spec.add_runtime_dependency "typesafe_enum"
 end


### PR DESCRIPTION
Resolves issue raised in https://github.com/openactive/models-ruby/pull/40#issuecomment-2176163705 by removing the pin, and adds a dependency so that the tests pass

Assuming this was why the pin was added in the first place @kieranj, as 7.0 previously made the tests fail?